### PR TITLE
Adjust "book create" workflow.

### DIFF
--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -9,6 +9,10 @@ module Admin
         book.title
       end
 
+      def index_action_columns
+        %w[edit works]
+      end
+
       def cover_column(book)
         if book.cover
           link_to image_tag(book.cover.thumb("x100").url), book.cover.url
@@ -21,6 +25,18 @@ module Admin
 
       def published_on_column(book)
         l(book.published_on, format: "%b %Y")
+      end
+
+      def works_column(book)
+        link_to "роботи", admin_works_path(book_id: book.id), class: "button"
+      end
+    end
+
+    def redirect_to_after(action)
+      if action == :create
+        redirect_to admin_works_path(book_id: resource.id), notice: redirect_to_after_notice(:create)
+      else
+        super
       end
     end
   end

--- a/app/views/admin/books/_form.slim
+++ b/app/views/admin/books/_form.slim
@@ -1,7 +1,3 @@
-- if resource.persisted?
-  .button-group
-    a.button href=new_admin_work_path(work: {book_id: resource.id}) target="_blank" Add work
-
 = simple_form_for [:admin, resource] do |f|
   = f.input :title
   = f.input :number_of_pages

--- a/app/views/admin/works/_index_header.slim
+++ b/app/views/admin/works/_index_header.slim
@@ -1,0 +1,1 @@
+a.button href=new_admin_work_path(work: {book_id: book&.id}) Додати ще

--- a/config/locales/admin.yml
+++ b/config/locales/admin.yml
@@ -8,6 +8,9 @@ uk:
     books:
       index:
         title: Книги
+      create:
+        notice:
+          Книгу було успішно додано. Будь ласка, вкажіть тих, хто над нею працював.
     people:
       index:
         title: Персони
@@ -17,3 +20,4 @@ uk:
     works:
       index:
         title: Роботи
+        title_for_book: Роботи до книги «%{title}»

--- a/spec/features/admin/books_spec.rb
+++ b/spec/features/admin/books_spec.rb
@@ -1,6 +1,27 @@
 require "rails_helper"
 
 RSpec.describe "Admin::BooksController" do
+  specify "#index" do
+    book = create(:book,
+                  title: "Зубр шукає гніздо",
+                  publisher_page_url: "https://starylev.com.ua/",
+                  published_on: "2016-09-16")
+
+    visit "/admin/books"
+
+    expect(page).to have_css :h1, text: /^Книги$/
+    expect(page.title).to eq "Книги | Admin"
+    expect(page).to have_link "Зубр шукає гніздо", href: "https://starylev.com.ua/"
+    expect(page).to have_content "Sep 2016"
+
+    click_on "правити"
+    expect(page).to have_content "Книги / Зубр шукає гніздо / Правити"
+
+    visit "/admin/books"
+    click_on "роботи"
+    expect(page).to have_content "Роботи до книги «Зубр шукає гніздо»"
+  end
+
   specify "#create" do
     visit "/admin/books/new"
 
@@ -15,12 +36,11 @@ RSpec.describe "Admin::BooksController" do
     attach_file "Обкладинка", "public/system/dragonfly/development/oksana-bula-vedmid.jpg"
     click_on "Додати книгу"
 
-    expect(page).to have_content "Запис було успішно створено"
-    expect(page).to have_css :h1, text: /^Книги$/
-    expect(page).to have_link "Ведмідь не хоче спати", href: "https://starylev.com.ua/"
-    expect(page).to have_content "Oct 2016"
+    expect(page).to have_content "Книгу було успішно додано. Будь ласка, вкажіть тих, хто над нею працював."
+    expect(page).to have_content "Роботи до книги «Ведмідь не хоче спати»"
 
-    click_on "правити"
+    visit "/admin/books/#{Book.last.id}/edit"
+
     expect(page).to have_field "Назва", with: "Ведмідь не хоче спати"
     expect(page).to have_field "Кількість сторінок", with: "30"
     expect(page).to have_field "Опис", with: "Опис цієї книги"
@@ -34,9 +54,9 @@ RSpec.describe "Admin::BooksController" do
     fill_in "Кількість сторінок", with: "30"
     click_on "Додати книгу"
 
-    expect(page).to have_content "Запис було успішно створено"
+    expect(page).to have_content "Книгу було успішно додано"
 
-    click_on "правити"
+    visit "/admin/books/#{Book.last.id}/edit"
     expect(page).to have_field "Назва", with: "Ведмідь"
   end
 
@@ -53,7 +73,7 @@ RSpec.describe "Admin::BooksController" do
 
     expect(page).to have_content "Запис було успішно оновлено"
 
-    click_on "правити"
+    visit "/admin/books/#{book.id}/edit"
     expect(page).to have_field "Назва", with: "Ведмідь не хоче спати"
   end
 end


### PR DESCRIPTION
The following steps are expected:

1) create book draft,
2) redirected to book's works page,
3) add new work,
4) back to step 2), repeat.

Testing index pages were extracted to a separate spec
to make them less brittle.