### PR TITLE
Allow a publisher to create people

### DIFF
--- a/app/policies/admin/person_policy.rb
+++ b/app/policies/admin/person_policy.rb
@@ -1,4 +1,21 @@
 module Admin
   class PersonPolicy < Admin::ApplicationPolicy
+    class Scope < Scope
+      def resolve
+        if user.admin? || user.publisher?
+          scope.all
+        else
+          scope.none
+        end
+      end
+    end
+
+    def index?
+      user.admin? || user.publisher?
+    end
+
+    def create?
+      user.admin? || user.publisher?
+    end
   end
 end

--- a/spec/policies/admin/person_policy_spec.rb
+++ b/spec/policies/admin/person_policy_spec.rb
@@ -3,7 +3,35 @@ require "rails_helper"
 RSpec.describe Admin::PersonPolicy do
   let(:policy) { described_class }
 
-  permissions :index?, :new?, :create?, :update?, :edit? do
+  permissions :index? do
+    it "denies access to just registered user" do
+      expect(policy).not_to permit(build(:user), Person.new)
+    end
+
+    it "grants access to publisher" do
+      expect(policy).to permit(build(:publisher_user), Person.new)
+    end
+
+    it "grants access to admin" do
+      expect(policy).to permit(build(:admin), Person.new)
+    end
+  end
+
+  permissions :new?, :create? do
+    it "denies access to just registered user" do
+      expect(policy).not_to permit(build(:user), Person.new)
+    end
+
+    it "grants access to publisher" do
+      expect(policy).to permit(build(:publisher_user), Person.new)
+    end
+
+    it "grants access to admin" do
+      expect(policy).to permit(build(:admin), Person.new)
+    end
+  end
+
+  permissions :edit?, :update? do
     it "denies access to just registered user" do
       expect(policy).not_to permit(build(:user), Person.new)
     end
@@ -29,8 +57,8 @@ RSpec.describe Admin::PersonPolicy do
       expect(policy_scope(build(:user))).to be_empty
     end
 
-    it "returns nothing for publisher" do
-      expect(policy_scope(build(:publisher_user))).to be_empty
+    it "returns everything for publisher" do
+      expect(policy_scope(build(:publisher_user))).to match [person1, person2]
     end
 
     it "returns everything for admin" do


### PR DESCRIPTION
Once new person is created it can be edited only by an admin. This is to prevent accidental editing of data that is shared between several publishers.