### PR TITLE
Switch image uploading to https://uploadcare.com

### DIFF
--- a/app/assets/stylesheets/admin/form.scss
+++ b/app/assets/stylesheets/admin/form.scss
@@ -2,8 +2,10 @@ textarea {
   height: 20rem;
 }
 
-.input.dragonfly {
-  & > img {
-    margin: 0.5rem 0 1rem;
+.input.uploadcare {
+  margin: 0.5rem 0 1rem;
+
+  img {
+    margin-right: 1em;
   }
 }

--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class BooksController < Admin::ApplicationController
-    expose(:index_columns) { %w[id state cover title published_on] }
+    expose(:index_columns) { %w[id state cover_url title published_on] }
     expose(:resource_collection) { Book.order("id desc") }
     expose(:resource, model: "Book")
 
@@ -17,9 +17,9 @@ module Admin
         link_to_if book.published?, t("simple_form.options.book.state.#{book.state}"), book_path(id: book), target: "_blank"
       end
 
-      def cover_column(book)
-        if book.cover
-          link_to image_tag(book.cover.thumb("x100").url), book.cover.url
+      def cover_url_column(book)
+        if book.cover_url?
+          link_to image_tag(Uploadcare.url(book.cover_url, resize: "x100")), book.cover_url
         end
       end
 

--- a/app/inputs/uploadcare_input.rb
+++ b/app/inputs/uploadcare_input.rb
@@ -1,0 +1,29 @@
+class UploadcareInput < SimpleForm::Inputs::Base
+  def input(wrapper_options = nil)
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    model = @builder.object
+    tags = []
+    tags << template.javascript_include_tag("https://ucarecdn.com/libs/widget/3.x/uploadcare.full.min.js", async: true)
+
+    url = model.public_send(attribute_name)
+    if url
+      tags << template.image_tag(Uploadcare.url(url, resize: "x100"))
+    end
+
+    tags << @builder.hidden_field(attribute_name, widget_options)
+    safe_join(tags)
+  end
+
+  private
+
+  # https://uploadcare.com/docs/file_uploads/widget/options
+  def widget_options(valid_to: 10.minutes.since)
+    {
+      "role" => "uploadcare-uploader",
+      "data-public-key" => Uploadcare::CONFIG.fetch("public_key"),
+      "data-secure-signature" => Uploadcare.signature(valid_to),
+      "data-secure-expire" => valid_to.to_i,
+    }
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -26,6 +26,16 @@ class Book < ApplicationRecord
     default "public/system/dragonfly/no_image.png"
   end
 
+  # Fix method being overridden by dragonfly
+  # https://github.com/markevans/dragonfly/blob/3ad0c6dded8f69773e042714be1f877b3c05797a/lib/dragonfly/model/class_methods.rb#L61-L71
+  def cover_url=(url)
+    self[:cover_url] = url
+  end
+
+  def cover_url
+    self[:cover_url]
+  end
+
   private
 
   def publisher_page_url_should_be_valid

--- a/app/models/uploadcare.rb
+++ b/app/models/uploadcare.rb
@@ -1,0 +1,16 @@
+class Uploadcare
+  CONFIG = Rails.application.config_for(:uploadcare)
+
+  class << self
+    # https://uploadcare.com/docs/image_transformations/
+    def url(cdn_url, operations)
+      pipeline = operations.map { |fn, arg| "-/#{fn}/#{arg}/" }.join
+      File.join(cdn_url, pipeline)
+    end
+
+    # https://uploadcare.com/docs/api_reference/upload/signed_uploads/
+    def signature(valid_to)
+      Digest::MD5.hexdigest "#{CONFIG.fetch("secret_key")}#{valid_to.to_i}"
+    end
+  end
+end

--- a/app/views/admin/books/_form.slim
+++ b/app/views/admin/books/_form.slim
@@ -7,5 +7,5 @@
   = f.input :description_md
   = f.input :published_on, html5: true
   = f.input :publisher_page_url
-  = f.input :cover, as: :dragonfly
+  = f.input :cover_url, as: :uploadcare
   = f.submit class: "button"

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -31,7 +31,7 @@ uk:
         description_md: Опис
         published_on: Дата подання до друку
         publisher_page_url: Посилання на книгу на сайті видавця
-        cover: Обкладинка
+        cover_url: Обкладинка
       person:
         first_name: Ім'я
         last_name: Прізвище

--- a/config/uploadcare.yml
+++ b/config/uploadcare.yml
@@ -1,0 +1,14 @@
+default: &default
+  public_key: 10b871ebc0271ab7d9ad
+  secret_key: not provided
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+  public_key: <%= ENV["UPLOADCARE_PUBLIC_KEY"] %>
+  secret_key: <%= ENV["UPLOADCARE_SECRET_KEY"] %>

--- a/db/migrate/20190303154345_add_cover_url_to_books.rb
+++ b/db/migrate/20190303154345_add_cover_url_to_books.rb
@@ -1,0 +1,5 @@
+class AddCoverUrlToBooks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :books, :cover_url, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -64,7 +64,8 @@ CREATE TABLE books (
     publisher_page_url character varying,
     description_md text,
     state character varying DEFAULT 'draft'::character varying NOT NULL,
-    publisher_id integer NOT NULL
+    publisher_id integer NOT NULL,
+    cover_url character varying
 );
 
 
@@ -595,6 +596,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180225184939'),
 ('20180325074547'),
 ('20180709114819'),
-('20180715175444');
+('20180715175444'),
+('20190303154345');
 
 

--- a/spec/factories/book.rb
+++ b/spec/factories/book.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
       серії оповідок про мешканців лісу.
     txt
     number_of_pages 32
-    cover_uid "oksana-bula-zubr.jpg"
+    cover_url "https://ucarecdn.com/25245d09-0e4a-494c-8666-bba90a442090/"
     publisher
 
     trait :published do

--- a/spec/features/admin/books_spec.rb
+++ b/spec/features/admin/books_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe "Admin::BooksController" do
       fill_in "Опис", with: "Опис цієї книги"
       select_date Date.new(2016, 10, 10), from: "Дата подання до друку"
       fill_in "Посилання на книгу на сайті видавця", with: "https://starylev.com.ua/"
-      attach_file "Обкладинка", "public/system/dragonfly/development/oksana-bula-vedmid.jpg"
       click_on "Додати книгу"
 
       expect(page).to have_content "Книгу було успішно додано. Будь ласка, вкажіть тих, хто над нею працював."

--- a/spec/models/uploadcare_spec.rb
+++ b/spec/models/uploadcare_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Uploadcare do
   end
 
   specify ".signature" do
-    valid_to = Time.new(2019, 3, 8, 17, 43, 30)
-    expect(Uploadcare.signature(valid_to)).to eq "268d154e610c96541a35b6f3c1386279"
+    valid_to = Time.utc(2019, 3, 8, 17, 43, 30)
+    expect(Uploadcare.signature(valid_to)).to eq "23aae6e66d5ff76899725747cc9f4712"
   end
 end

--- a/spec/models/uploadcare_spec.rb
+++ b/spec/models/uploadcare_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Uploadcare do
+  describe ".url" do
+    specify "one operation" do
+      url = Uploadcare.url("https://ucarecdn.com/:uuid/", resize: "x100")
+      expect(url).to eq "https://ucarecdn.com/:uuid/-/resize/x100/"
+    end
+
+    specify "two operations" do
+      url = Uploadcare.url("https://ucarecdn.com/:uuid/", resize: "x100", format: "webp")
+      expect(url).to eq "https://ucarecdn.com/:uuid/-/resize/x100/-/format/webp/"
+    end
+  end
+
+  specify ".signature" do
+    valid_to = Time.new(2019, 3, 8, 17, 43, 30)
+    expect(Uploadcare.signature(valid_to)).to eq "268d154e610c96541a35b6f3c1386279"
+  end
+end


### PR DESCRIPTION
This is part 1 of the migration.
In this one admin form is switched to Uploadcare widget.
When all images will be re-uploaded, we can remove dragonfly remains.