### PR TITLE
Remove Dragonfly's Book#cover_uid column

### DIFF
--- a/db/migrate/20190526161252_remove_books_cover_uid.rb
+++ b/db/migrate/20190526161252_remove_books_cover_uid.rb
@@ -1,0 +1,8 @@
+class RemoveBooksCoverUid < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :books, :cover_uid
+  end
+
+  def down
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,8 +7,8 @@ oksana_bula = FactoryGirl.create(:person, first_name: "Оксана", last_name:
 
 leva_publishing = FactoryGirl.create(:publisher, name: "Видавництво Старого Лева")
 
-zubr = FactoryGirl.create(:book, title: "Зубр шукає гніздо", cover_uid: "oksana-bula-zubr.jpg", publisher: leva_publishing)
-vedmid = FactoryGirl.create(:book, title: "Ведмідь не хоче спати", cover_uid: "oksana-bula-vedmid.jpg", publisher: leva_publishing)
+zubr = FactoryGirl.create(:book, title: "Зубр шукає гніздо", publisher: leva_publishing)
+vedmid = FactoryGirl.create(:book, title: "Ведмідь не хоче спати", publisher: leva_publishing)
 
 Work.create!(title: true, book: zubr, person_alias: oksana_bula.main_alias, type: text_author_type)
 Work.create!(book: zubr, person_alias: oksana_bula.main_alias, type: illustrator_type)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -60,7 +60,6 @@ CREATE TABLE books (
     updated_at timestamp without time zone NOT NULL,
     published_on date DEFAULT ('now'::text)::date NOT NULL,
     number_of_pages integer NOT NULL,
-    cover_uid character varying,
     publisher_page_url character varying,
     description_md text,
     state character varying DEFAULT 'draft'::character varying NOT NULL,
@@ -597,6 +596,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180325074547'),
 ('20180709114819'),
 ('20180715175444'),
-('20190303154345');
+('20190303154345'),
+('20190526161252');
 
 


### PR DESCRIPTION
This is final part of [the migration](https://github.com/ua-books/ua-books/issues/33).
Also the system/dragonfly directory was removed manually from the production server.
