### PR TITLE
rack-cache is no longer needed.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'turbolinks', '~> 5'
 gem 'foundation-rails', '~> 6.4'
 
 gem 'bootsnap', '~> 1.1', require: false
-gem 'rack-cache'
 
 gem 'omniauth-google-oauth2', '~> 0.5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,8 +133,6 @@ GEM
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.0.8)
-    rack-cache (1.7.1)
-      rack (>= 0.4)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.6.2)
@@ -253,7 +251,6 @@ DEPENDENCIES
   pg (~> 0.18)
   puma (~> 3.12)
   pundit (~> 2.0)
-  rack-cache
   rails (= 5.1.6.2)
   redcarpet (~> 3.4)
   rspec-rails (~> 3.6)

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,5 @@ module UaBooks
     config.i18n.fallbacks = [:en]
 
     config.time_zone = "Europe/Kiev"
-
-    config.action_dispatch.rack_cache = true
   end
 end


### PR DESCRIPTION
It was only used for caching assets generated on the fly
by dragonfly.

This reverts commit 02d3c6653c12ba774cab08bd5f8e3f88dbcbac68.

This is a cleanup after [the migration](https://github.com/ua-books/ua-books/issues/33).
