### PR TITLE
Revert "Apply for free service from cloud66.com."

### DIFF
--- a/app/assets/stylesheets/application/footer_container.scss
+++ b/app/assets/stylesheets/application/footer_container.scss
@@ -6,9 +6,4 @@
   > .menu {
     margin-bottom: $global-margin;
   }
-
-  > .cloud66 > img {
-    margin: 1em 0;
-    width: 35ch;
-  }
 }

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -36,9 +36,6 @@ html
         div © 2017–2018 Українські книжки
         div Замислено в Харкові з любові до світу.
 
-        a.cloud66 href="http://www.cloud66.com"
-          img src="https://assets.cloud66.com/public/powered-by-cloud66.png" title="Powered by Cloud 66"
-
     javascript:
       var canonicalLink = document.querySelector("[rel='canonical']");
       var canonicalHref = canonicalLink ? canonicalLink.href : window.location.href;


### PR DESCRIPTION
This reverts commit bca27b1c7cfe35c593bdebcb08fbdd92906272aa.

Cloud66 [no longer provides a free plan](https://www.cloud66.com/rails/pricing/). ua-books had to switch to a paid plan, so we don't have to show their banner.