### PR TITLE
Bump puma (bugfix after a security fix).

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       omniauth (~> 1.9)
     pg (0.21.0)
     public_suffix (3.0.0)
-    puma (3.12.3)
+    puma (3.12.4)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
     rack (2.2.2)


### PR DESCRIPTION
https://github.com/ua-books/ua-books/pull/49 prevented cookies to be set (see [notes](https://github.com/puma/puma/blob/master/History.md#433-and-3124--2020-02-28))