### PR TITLE
Allow to upload images in development

### DIFF
--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -1,10 +1,36 @@
+module Dragonfly
+  module DevS3DataStore
+    private
+
+    # https://github.com/markevans/dragonfly-s3_data_store/blob/15ba3f39a/lib/dragonfly/s3_data_store.rb#L126-L128
+    def generate_uid(name)
+      "dev/#{super}"
+    end
+  end
+end
+
 Dragonfly.app.configure do
-  datastore :s3,
-    region: "eu-central-1",
-    bucket_name: "ua-books",
-    storage_headers: {}, # remove `{'x-amz-acl' => 'public-read'}` defaults
-    access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-    secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]
+  case Rails.env
+  when "development"
+    datastore :s3,
+      region: "eu-central-1",
+      bucket_name: "ua-books",
+      storage_headers: {}, # remove `{'x-amz-acl' => 'public-read'}` defaults
+      # these credentials are scoped to /dev folder only, so are safe to share in public
+      access_key_id: "AKIA53OKKD65DGWLU4QJ",
+      secret_access_key: "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"
+
+    Dragonfly::S3DataStore.class_eval do
+      prepend Dragonfly::DevS3DataStore
+    end
+  else
+    datastore :s3,
+      region: "eu-central-1",
+      bucket_name: "ua-books",
+      storage_headers: {}, # remove `{'x-amz-acl' => 'public-read'}` defaults
+      access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]
+  end
 end
 
 Dragonfly.logger = Rails.logger


### PR DESCRIPTION
This is part 2 for [the migration](https://github.com/ua-books/ua-books/issues/45).

It allows a developer to upload her/his own covers to s3. This way we don't have to have a special image processing proxy in development and can benefit from the same production proxy (currently imagekit.io).

IAM user is specified as write-only *and* is scoped to /dev folder, so that an attacker can't use them to overwrite/delete production images:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": [
                "s3:PutObject",
                "s3:DeleteObject",
                "s3:GetBucketLocation"
            ],
            "Resource": [
                "arn:aws:s3:::ua-books",
                "arn:aws:s3:::ua-books/dev/*"
            ]
        }
    ]
}
```

See markevans/dragonfly-s3_data_store#30 (comment) on why s3:GetBucketLocation is needed.