### PR TITLE
Switch image processing to imagekit.io

### DIFF
--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -18,8 +18,8 @@ module Admin
       end
 
       def cover_url_column(book)
-        if book.cover_url?
-          link_to image_tag(Uploadcare.url(book.cover_url, resize: "x100")), book.cover_url
+        if book.cover_uid?
+          link_to imagekit_hd_image_tag(book.cover_uid, tr: {w: 100}), imagekit_url(book.cover_uid)
         end
       end
 

--- a/app/helpers/imagekit_helper.rb
+++ b/app/helpers/imagekit_helper.rb
@@ -1,0 +1,26 @@
+module ImagekitHelper
+  def imagekit_url(uid, tr: {})
+    if tr.present?
+      transformation_path = tr.map { |key, val| "#{key}-#{val}" }.join(",")
+      "https://ik.imagekit.io/uabooks/tr:#{transformation_path}/#{uid}"
+    else
+      "https://ik.imagekit.io/uabooks/#{uid}"
+    end
+  end
+
+  # Adds 2x and 3x sources using "dpr" param, see
+  # https://docs.imagekit.io/features/image-transformations/resize-crop-and-other-transformations
+  def imagekit_hd_image_tag(uid, options)
+    transformations = options.fetch(:tr)
+    image_tag_options = options.except(:tr)
+
+    srcsets = [2, 3].map do |pixel_ratio|
+      "#{imagekit_url(uid, tr: transformations.merge(dpr: pixel_ratio))} #{pixel_ratio}x"
+    end
+    srcset = srcsets.join(", ")
+
+    base_url = imagekit_url(uid, tr: transformations)
+
+    image_tag(base_url, image_tag_options.merge(srcset: srcset))
+  end
+end

--- a/app/views/books/show.slim
+++ b/app/views/books/show.slim
@@ -9,10 +9,11 @@ article.book-article
   h1.title = book_title
 
   .media-object.stack-for-small
-    .media-object-section
-      figure
-        picture
-          img src=Uploadcare.url(book.cover_url, resize: "640x") alt=book_title
+    - if book.cover_uid?
+      .media-object-section
+        figure
+          picture
+            = imagekit_hd_image_tag(book.cover_uid, alt: book_title, tr: {w: 640})
 
     .media-object-section.main-section
       dl.inline

--- a/app/views/sitemap/show.xml.slim
+++ b/app/views/sitemap/show.xml.slim
@@ -5,6 +5,7 @@ urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://w
       loc = book_url(id: book.id)
       changefreq always
       lastmod = book.updated_at.to_formatted_s(:iso8601)
-      image:image
-        image:loc = Uploadcare.url(book.cover_url, resize: "640x")
-        image:title Обкладинка до книги «#{book.title}»
+      - if book.cover_uid?
+        image:image
+          image:loc = imagekit_url(book.cover_uid, tr: {w: 640})
+          image:title Обкладинка до книги «#{book.title}»

--- a/spec/requests/sitemap_spec.rb
+++ b/spec/requests/sitemap_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "/sitemap.xml" do
   specify "published book" do
-    book = create(:book, :published, title: "Зубр шукає гніздо", updated_at: "2017-12-11")
+    book = create(:book, :published, title: "Зубр шукає гніздо", updated_at: "2017-12-11", cover_uid: "dev/test.jpg")
 
     get "/sitemap.xml"
 
@@ -15,8 +15,21 @@ RSpec.describe "/sitemap.xml" do
     expect(url).to have_selector("lastmod", text: "2017-12-11T00:00:00")
     expect(url).to have_selector("image")
     image = url.find("image")
-    expect(image).to have_selector("loc", text: book.cover_url)
+    expect(image).to have_selector("loc", text: "dev/test.jpg")
     expect(image).to have_selector("title", text: "Обкладинка до книги «Зубр шукає гніздо»")
+  end
+
+  specify "published book w/o cover" do
+    book = create(:book, :published)
+
+    get "/sitemap.xml"
+
+    xml = Capybara.string(response.body)
+    xml.native.remove_namespaces!
+    expect(xml).to have_selector(:xpath, "//urlset/url")
+    url = xml.find(:xpath, "//urlset/url")
+
+    expect(url).to_not have_selector("image")
   end
 
   specify "draft book" do


### PR DESCRIPTION
This is part 3 for [the migration](https://github.com/ua-books/ua-books/issues/45).

It uses https://imagekit.io/ as an image processing proxy.
AWS S3 bucket is specified as a [source](https://docs.imagekit.io/integration/configure-origin/amazon-s3-bucket-origin). IAM policy is read-only:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::ua-books/*"
        }
    ]
}
```

Notice, this allows imagekit service to read both production (root) and dev/ files. That means a production dump would be still useful on a local machine.