### PR TITLE
Ensure work types have unique names

### DIFF
--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -5,4 +5,5 @@
 # are equal.
 class WorkType < ApplicationRecord
   validates_presence_of :name_feminine, :name_masculine
+  validates_uniqueness_of :name_feminine, :name_masculine
 end


### PR DESCRIPTION
While manually adding new types via admin UI I managed to create duplicates even though the list was quite small. In the future this list will only grow, so does the probability of duplicates.
For now it's enough to have only AR-backed validation (no unique index in DB has been added).