### PR TITLE
Rename AuthorAlias#person_id to #author_id

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -6,7 +6,7 @@ class Author < ApplicationRecord
   validates_presence_of :first_name, :last_name, :gender
   validates_inclusion_of :gender, in: %w[female male]
 
-  has_many :aliases, foreign_key: "person_id", class_name: "AuthorAlias", inverse_of: :author
+  has_many :aliases, class_name: "AuthorAlias", inverse_of: :author
 
   after_create do
     aliases.create!(first_name: first_name, last_name: last_name)

--- a/app/models/author_alias.rb
+++ b/app/models/author_alias.rb
@@ -6,5 +6,5 @@
 class AuthorAlias < ApplicationRecord
   validates_presence_of :first_name, :last_name
 
-  belongs_to :author, foreign_key: "person_id", inverse_of: :aliases
+  belongs_to :author, inverse_of: :aliases
 end

--- a/db/migrate/20210110161606_rename_person_id_to_author_id.rb
+++ b/db/migrate/20210110161606_rename_person_id_to_author_id.rb
@@ -1,0 +1,5 @@
+class RenamePersonIdToAuthorId < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :author_aliases, :person_id, :author_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -57,7 +57,7 @@ CREATE TABLE author_aliases (
     id bigint NOT NULL,
     first_name character varying NOT NULL,
     last_name character varying NOT NULL,
-    person_id bigint NOT NULL,
+    author_id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -463,10 +463,10 @@ ALTER TABLE ONLY works
 
 
 --
--- Name: index_author_aliases_on_person_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_author_aliases_on_author_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_author_aliases_on_person_id ON author_aliases USING btree (person_id);
+CREATE INDEX index_author_aliases_on_author_id ON author_aliases USING btree (author_id);
 
 
 --
@@ -563,7 +563,7 @@ ALTER TABLE ONLY users
 --
 
 ALTER TABLE ONLY author_aliases
-    ADD CONSTRAINT fk_rails_a4cf4f8aaa FOREIGN KEY (person_id) REFERENCES authors(id);
+    ADD CONSTRAINT fk_rails_a4cf4f8aaa FOREIGN KEY (author_id) REFERENCES authors(id);
 
 
 --
@@ -601,6 +601,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200223083804'),
 ('20200301092726'),
 ('20210110144352'),
-('20210110154703');
+('20210110154703'),
+('20210110161606');
 
 


### PR DESCRIPTION
This is part 3 of the https://github.com/ua-books/ua-books/issues/63.
Renaming a column in place would lead to runtime exceptions in between the rename and code reload, but we do not care, since current traffic is zero (except for crawlers).