### PR TITLE
Rename Work#person_alias_id to #author_alias_id

### DIFF
--- a/app/controllers/admin/works_controller.rb
+++ b/app/controllers/admin/works_controller.rb
@@ -3,7 +3,7 @@ module Admin
     expose(:index_columns) { %w[id book type author_alias notes] }
     expose(:book) { params[:book_id].presence && Book.find(params[:book_id]) }
     expose(:resource_collection) do
-      scope = Work.preload(:book, :type, author_alias: :author).order(:book_id, :person_alias_id)
+      scope = Work.preload(:book, :type, author_alias: :author).order(:book_id, :author_alias_id)
       if book
         scope = scope.where(book_id: book.id)
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   # With `:works` option you can make additional filtering/preloading of `book.works`
   # without passing the logic into the helper.
   def book_title(book, works: book.works)
-    author_aliases = works.find_all(&:title?).uniq(&:person_alias_id).map do |work|
+    author_aliases = works.find_all(&:title?).uniq(&:author_alias_id).map do |work|
       author_alias(work.author_alias)
     end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -11,9 +11,9 @@
 class Work < ApplicationRecord
   belongs_to :book, inverse_of: :works
   belongs_to :type, class_name: "WorkType", foreign_key: "work_type_id"
-  belongs_to :author_alias, foreign_key: "person_alias_id"
+  belongs_to :author_alias
 
-  validates_uniqueness_of :book_id, scope: [:person_alias_id, :work_type_id]
+  validates_uniqueness_of :book_id, scope: [:author_alias_id, :work_type_id]
 
   delegate :author, to: :author_alias
 

--- a/db/migrate/20210110163351_rename_person_alias_id_to_author_alias_id.rb
+++ b/db/migrate/20210110163351_rename_person_alias_id_to_author_alias_id.rb
@@ -1,0 +1,5 @@
+class RenamePersonAliasIdToAuthorAliasId < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :works, :person_alias_id, :author_alias_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -300,7 +300,7 @@ ALTER SEQUENCE work_types_id_seq OWNED BY work_types.id;
 CREATE TABLE works (
     id bigint NOT NULL,
     book_id bigint NOT NULL,
-    person_alias_id bigint NOT NULL,
+    author_alias_id bigint NOT NULL,
     work_type_id bigint NOT NULL,
     title boolean DEFAULT false NOT NULL,
     notes character varying
@@ -498,17 +498,17 @@ CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
--- Name: index_works_on_book_id_and_person_alias_id_and_work_type_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_works_on_author_alias_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_works_on_book_id_and_person_alias_id_and_work_type_id ON works USING btree (book_id, person_alias_id, work_type_id);
+CREATE INDEX index_works_on_author_alias_id ON works USING btree (author_alias_id);
 
 
 --
--- Name: index_works_on_person_alias_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_works_on_book_id_and_author_alias_id_and_work_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_works_on_person_alias_id ON works USING btree (person_alias_id);
+CREATE UNIQUE INDEX index_works_on_book_id_and_author_alias_id_and_work_type_id ON works USING btree (book_id, author_alias_id, work_type_id);
 
 
 --
@@ -539,7 +539,7 @@ ALTER TABLE ONLY oauth_providers
 --
 
 ALTER TABLE ONLY works
-    ADD CONSTRAINT fk_rails_86dd05cfb5 FOREIGN KEY (person_alias_id) REFERENCES author_aliases(id);
+    ADD CONSTRAINT fk_rails_86dd05cfb5 FOREIGN KEY (author_alias_id) REFERENCES author_aliases(id);
 
 
 --
@@ -602,6 +602,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200301092726'),
 ('20210110144352'),
 ('20210110154703'),
-('20210110161606');
+('20210110161606'),
+('20210110163351');
 
 


### PR DESCRIPTION
This is part 4 of the https://github.com/ua-books/ua-books/issues/63.
Renaming a column in place would lead to runtime exceptions in between the rename and code reload, but we do not care, since current traffic is zero (except for crawlers).