### PR TITLE
Use route helpers in specs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,10 @@ Rails.application.routes.draw do
   get "(:slug)/:id" => "books#show", as: :book, constraints: {id: /\d+/}
   get "/" => "home#show", as: :root
   get "/:path", to: "static#show", as: :static, constraints: {path: /about|helping-us/}
-  get "/sitemap.xml", to: "sitemap#show"
+  get "/sitemap.xml", as: :sitemap, to: "sitemap#show"
 
   match "/auth/:provider/callback", to: "omniauth_sessions#create",
+    as: :omniauth_sessions,
     via: [:get, :post],
     constraints: {provider: Regexp.union(OauthProvider.names.values)}
 

--- a/spec/features/admin/authors_spec.rb
+++ b/spec/features/admin/authors_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe "Admin::AuthorsController" do
   let(:publisher_user) { create(:publisher_user) }
 
   include_examples "features" do
-    let(:page_url) { "/admin/authors" }
+    let(:page_url) { admin_authors_path }
   end
 
   %i[admin publisher_user].each do |user|
     specify "#create #{user}" do
-      visit "/admin/authors/new"
+      visit new_admin_author_path
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: %r{^Автори / Додати$}
@@ -38,7 +38,7 @@ RSpec.describe "Admin::AuthorsController" do
   specify "#update" do
     oksana = create(:author, first_name: "Оксана", last_name: "Була")
 
-    visit "/admin/authors/#{oksana.id}/edit"
+    visit edit_admin_author_path(oksana)
     sign_in_as admin
 
     expect(page).to have_css :h1, text: %r{^Автори / Оксана Була / Правити$}

--- a/spec/features/admin/books_spec.rb
+++ b/spec/features/admin/books_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Admin::BooksController" do
   let(:publisher) { create(:publisher, name: "Старий Лев") }
 
   include_examples "features" do
-    let(:page_url) { "/admin/books" }
+    let(:page_url) { admin_books_path }
   end
 
   %i[admin publisher_user].each do |user|
@@ -18,7 +18,7 @@ RSpec.describe "Admin::BooksController" do
                     publisher_page_url: "https://starylev.com.ua/",
                     published_on: "2016-09-16")
 
-      visit "/admin/books"
+      visit admin_books_path
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: /^Книги$/
@@ -30,7 +30,7 @@ RSpec.describe "Admin::BooksController" do
       click_on "правити"
       expect(page).to have_content "Книги / Зубр шукає гніздо / Правити"
 
-      visit "/admin/books"
+      visit admin_books_path
       click_on "роботи"
       expect(page).to have_content "Роботи до книги «Зубр шукає гніздо»"
     end
@@ -38,7 +38,7 @@ RSpec.describe "Admin::BooksController" do
     specify "#index #{user} with a draft book" do
       book = create(:book, title: "Ця книга ще не опублікована на сайті", publisher: publisher)
 
-      visit "/admin/books"
+      visit admin_books_path
       sign_in_as public_send(user)
 
       expect(page).to have_content "Ця книга ще не опублікована на сайті"
@@ -47,7 +47,7 @@ RSpec.describe "Admin::BooksController" do
 
     specify "#create #{user}" do
       publisher
-      visit "/admin/books/new"
+      visit new_admin_book_path
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: %r{^Книги / Додати$}
@@ -65,7 +65,7 @@ RSpec.describe "Admin::BooksController" do
       expect(page).to have_content "Книгу було успішно додано. Будь ласка, вкажіть тих, хто над нею працював."
       expect(page).to have_content "Роботи до книги «Ведмідь не хоче спати»"
 
-      visit "/admin/books/#{Book.last.id}/edit"
+      visit edit_admin_book_path(Book.last)
 
       expect(page).to have_select "Стан", selected: "чорновик"
       expect(page).to have_select "Видавництво", selected: "Старий Лев"
@@ -77,7 +77,7 @@ RSpec.describe "Admin::BooksController" do
     end
 
     specify "#create with a prefilled form (#{user})" do
-      visit "/admin/books/new?book[title]=#{CGI.escape "Ведмідь"}"
+      visit new_admin_book_path(book: {title: "Ведмідь"})
       sign_in_as public_send(user)
       expect(page).to have_field "Назва", with: "Ведмідь"
     end
@@ -85,7 +85,7 @@ RSpec.describe "Admin::BooksController" do
     specify "#update #{user}" do
       book = create(:book, publisher: publisher, title: "Зубр шукає гніздо")
 
-      visit "/admin/books/#{book.id}/edit"
+      visit edit_admin_book_path(book)
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: %r{^Книги / Зубр шукає гніздо / Правити$}
@@ -96,7 +96,7 @@ RSpec.describe "Admin::BooksController" do
 
       expect(page).to have_content "Запис було успішно оновлено"
 
-      visit "/admin/books/#{book.id}/edit"
+      visit edit_admin_book_path(book)
       expect(page).to have_field "Назва", with: "Ведмідь не хоче спати"
     end
   end

--- a/spec/features/admin/publishers_spec.rb
+++ b/spec/features/admin/publishers_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Admin::PublishersController" do
   let(:admin) { create(:admin) }
 
   include_examples "features" do
-    let(:page_url) { "/admin/publishers" }
+    let(:page_url) { admin_publishers_path }
   end
 
   specify "#index" do
     book = create(:publisher,
                   name: "Старий Лев")
 
-    visit "/admin/publishers"
+    visit admin_publishers_path
     sign_in_as admin
 
     expect(page).to have_css :h1, text: /^Видавництва$/
@@ -23,7 +23,7 @@ RSpec.describe "Admin::PublishersController" do
   end
 
   specify "#create" do
-    visit "/admin/publishers/new"
+    visit new_admin_publisher_path
     sign_in_as admin
 
     expect(page).to have_css :h1, text: %r{^Видавництва / Додати$}
@@ -34,7 +34,7 @@ RSpec.describe "Admin::PublishersController" do
 
     expect(page).to have_content "Запис було успішно створено"
 
-    visit "/admin/publishers/#{Publisher.last.id}/edit"
+    visit edit_admin_publisher_path(Publisher.last)
 
     expect(page).to have_field "Назва", with: "Видавництво Старого Лева"
   end
@@ -42,7 +42,7 @@ RSpec.describe "Admin::PublishersController" do
   specify "#update" do
     publisher = create(:publisher, name: "Видавництво Старого Лева")
 
-    visit "/admin/publishers/#{publisher.id}/edit"
+    visit edit_admin_publisher_path(publisher)
     sign_in_as admin
 
     expect(page).to have_css :h1, text: %r{^Видавництва / Видавництво Старого Лева / Правити$}
@@ -53,7 +53,7 @@ RSpec.describe "Admin::PublishersController" do
 
     expect(page).to have_content "Запис було успішно оновлено"
 
-    visit "/admin/publishers/#{publisher.id}/edit"
+    visit edit_admin_publisher_path(publisher)
     expect(page).to have_field "Назва", with: "Старий Лев"
   end
 end

--- a/spec/features/admin/work_types_spec.rb
+++ b/spec/features/admin/work_types_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe "Admin::WorkTypesController" do
   let(:admin) { create(:admin) }
 
   include_examples "features" do
-    let(:page_url) { "/admin/work_types" }
+    let(:page_url) { admin_work_types_path }
   end
 
   specify "#create" do
-    visit "/admin/work_types/new"
+    visit new_admin_work_type_path
     sign_in_as admin
 
     expect(page).to have_css :h1, text: %r{^Типи робіт / Додати$}
@@ -31,7 +31,7 @@ RSpec.describe "Admin::WorkTypesController" do
   specify "#update" do
     illustrator_type = create(:illustrator_type, name_masculine: "Ілюстратор")
 
-    visit "/admin/work_types/#{illustrator_type.id}/edit"
+    visit edit_admin_work_type_path(illustrator_type)
     sign_in_as admin
 
     expect(page).to have_css :h1, text: %r{^Типи робіт / Ілюстратор / Правити$}

--- a/spec/features/admin/works_spec.rb
+++ b/spec/features/admin/works_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Admin::WorkController" do
   let(:publisher_user) { create(:publisher_user, publisher: publisher) }
 
   include_examples "features" do
-    let(:page_url) { "/admin/works" }
+    let(:page_url) { admin_works_path }
   end
 
   %i[admin publisher_user].each do |user|
     specify "#index #{user}" do
       create(:work, book: zubr_book, type: text_author_type, author_alias: oksana_bula.main_alias, notes: "2008")
 
-      visit "/admin/works"
+      visit admin_works_path
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: /^Роботи$/
@@ -33,7 +33,7 @@ RSpec.describe "Admin::WorkController" do
     end
 
     specify "#create #{user}" do
-      visit "/admin/works/new?work[book_id]=#{zubr_book.id}"
+      visit new_admin_work_path(work: {book_id: zubr_book})
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: %r{^Роботи / Додати$}
@@ -48,7 +48,7 @@ RSpec.describe "Admin::WorkController" do
       expect(page).to have_content "Запис було успішно створено"
       expect(page).to have_content "Роботи до книги «Зубр шукає гніздо»"
 
-      visit "/admin/works/#{Work.last.id}/edit"
+      visit edit_admin_work_path(Work.last)
 
       expect(page).to have_checked_field "У заголовку"
       expect(page).to have_select "Книга", selected: "Зубр шукає гніздо"
@@ -61,7 +61,7 @@ RSpec.describe "Admin::WorkController" do
       create(:illustrator_type)
       work = create(:work, book: zubr_book, type: text_author_type, author_alias: oksana_bula.main_alias)
 
-      visit "/admin/works/#{work.id}/edit"
+      visit edit_admin_work_path(work)
       sign_in_as public_send(user)
 
       expect(page).to have_css :h1, text: %r{^Роботи / Зубр шукає гніздо - Авторка тексту - Оксана Була / Правити$}
@@ -72,7 +72,7 @@ RSpec.describe "Admin::WorkController" do
 
       expect(page).to have_content "Запис було успішно оновлено"
 
-      visit "/admin/works/#{work.id}/edit"
+      visit edit_admin_work_path(work)
       expect(page).to have_select "Тип робіт", selected: "Ілюстратор"
     end
   end

--- a/spec/features/authors_spec.rb
+++ b/spec/features/authors_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "AuthorsController" do
     book = create(:book, :published, title: "Зубр шукає гніздо")
     create(:work, author_alias: oksana.main_alias, book: book, type: create(:text_author_type))
 
-    visit "/a/#{oksana.id}"
+    visit author_path(id: oksana)
     expect(page).to have_css :h1, text: /^Оксана Була$/
 
     expect(page).to have_text "Авторка тексту"
@@ -21,7 +21,7 @@ RSpec.describe "AuthorsController" do
     book = create(:book, title: "Зубр шукає гніздо")
     create(:work, author_alias: oksana.main_alias, book: book)
 
-    visit "/a/#{oksana.id}"
+    visit author_path(id: oksana)
     expect(page).to have_css :h1, text: /^Оксана Була$/
     expect(page).to_not have_content("Авторка тексту")
     expect(page).to_not have_content("Зубр шукає гніздо")
@@ -38,7 +38,7 @@ RSpec.describe "AuthorsController" do
     oksana_alias = AuthorAlias.create!(author: oksana, first_name: "Придумувачка", last_name: "Туконі")
     create(:work, author_alias: oksana_alias, book: book3, type: create(:illustrator_type))
 
-    visit "/a/#{oksana.id}"
+    visit author_path(id: oksana)
 
     expect(page).to have_text "Авторка тексту Оксана Була «Зубр шукає гніздо» Оксана Була «Ведмідь не хоче спати» Ілюстраторка Придумувачка Туконі «Туконі. Мешканець лісу»"
 

--- a/spec/features/books_spec.rb
+++ b/spec/features/books_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "BooksController" do
     create(:work, author_alias: oksana.main_alias, type: create(:illustrator_type), book: book, notes: "включно з обкладинкою")
     create(:work, author_alias: maryana.main_alias, type: create(:chief_editor_type), book: book, title: false)
 
-    visit "/#{book.id}"
+    visit book_path(id: book)
     expect(page).to have_css :h1, text: /^Оксана Була «Зубр шукає гніздо»$/
     expect(page).to have_content "Видавництво Старий Лев"
     expect(page).to have_link "Старий Лев", href: publisher_path(id: leva_publishing, slug: "видавництво-старий-лев")
@@ -50,7 +50,7 @@ RSpec.describe "BooksController" do
     let(:book) { create(:book, title: "Зубр шукає гніздо", publisher: leva_publishing) }
 
     specify "is not allowed when visited as anonymous" do
-      visit "/#{book.id}"
+      visit book_path(id: book)
       expect(page).to have_content "The page you were looking for doesn't exist."
     end
 
@@ -58,7 +58,7 @@ RSpec.describe "BooksController" do
       admin = create(:admin)
       sign_in_as admin
 
-      visit "/#{book.id}"
+      visit book_path(id: book)
       expect(page).to have_content "Зубр шукає гніздо"
       expect(page).to have_content "Старий Лев"
     end
@@ -67,7 +67,7 @@ RSpec.describe "BooksController" do
       leva_publishing_user = create(:publisher_user, publisher: leva_publishing)
       sign_in_as leva_publishing_user
 
-      visit "/#{book.id}"
+      visit book_path(id: book)
       expect(page).to have_content "Зубр шукає гніздо"
       expect(page).to have_content "Старий Лев"
     end
@@ -76,7 +76,7 @@ RSpec.describe "BooksController" do
       shady_publishing_user = create(:publisher_user)
       sign_in_as shady_publishing_user
 
-      visit "/#{book.id}"
+      visit book_path(id: book)
       expect(page).to have_content "The page you were looking for doesn't exist."
     end
   end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Home page" do
     oksana = create(:author, first_name: "Оксана", last_name: "Була")
     create(:work, author_alias: oksana.main_alias, book: book)
 
-    visit "/"
+    visit root_path
     expect(page).to have_content "Українські книжки"
     expect(page.title).to eq "Українські книжки"
     expect(page).to have_link("Оксана Була «Зубр шукає гніздо»", href: "/#{CGI.escape "оксана-була-зубр-шукає-гніздо"}/#{book.id}")
@@ -15,7 +15,7 @@ RSpec.describe "Home page" do
   specify "draft book" do
     create(:book, title: "Зубр шукає гніздо")
 
-    visit "/"
+    visit root_path
     expect(page).to_not have_content("Зубр шукає гніздо")
   end
 end

--- a/spec/features/publishers_spec.rb
+++ b/spec/features/publishers_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "PublishersController" do
     oksana = create(:author, first_name: "Оксана", last_name: "Була")
     create(:work, author_alias: oksana.main_alias, book: book)
 
-    visit "/p/#{leva_publishing.id}"
+    visit publisher_path(id: leva_publishing)
     expect(page).to have_css :h1, text: /^Видавництво «Старий Лев»$/
 
     expect(page).to have_link("Оксана Була «Зубр шукає гніздо»", href: "/#{CGI.escape "оксана-була-зубр-шукає-гніздо"}/#{book.id}")
@@ -20,14 +20,14 @@ RSpec.describe "PublishersController" do
   specify "draft book from the same publisher" do
     create(:book, title: "Зубр шукає гніздо", publisher: leva_publishing)
 
-    visit "/p/#{leva_publishing.id}"
+    visit publisher_path(id: leva_publishing)
     expect(page).to_not have_content("Зубр шукає гніздо")
   end
 
   specify "published book from another publisher" do
     create(:book, :published, title: "Зубр шукає гніздо")
 
-    visit "/p/#{leva_publishing.id}"
+    visit publisher_path(id: leva_publishing)
     expect(page).to_not have_content("Зубр шукає гніздо")
   end
 end

--- a/spec/features/static_spec.rb
+++ b/spec/features/static_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe "Static page" do
   specify "/about" do
-    visit "/about"
+    visit static_path(path: "about")
     expect(page).to have_content "Про нас"
     expect(page.title).to eq "Про нас на Українських книжках"
   end
 
   specify "/helping-us" do
-    visit "/helping-us"
+    visit static_path(path: "helping-us")
     expect(page).to have_content "Як можна допомогти"
     expect(page.title).to eq "Як можна допомогти на Українських книжках"
   end

--- a/spec/requests/sitemap_spec.rb
+++ b/spec/requests/sitemap_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "/sitemap.xml" do
     oksana = create(:author, first_name: "Оксана", last_name: "Була")
     create(:work, author_alias: oksana.main_alias, book: book)
 
-    get "/sitemap.xml"
+    get sitemap_path
 
     xml = Capybara.string(response.body)
     xml.native.remove_namespaces!
@@ -24,7 +24,7 @@ RSpec.describe "/sitemap.xml" do
   specify "published book w/o cover" do
     book = create(:book, :published)
 
-    get "/sitemap.xml"
+    get sitemap_path
 
     xml = Capybara.string(response.body)
     xml.native.remove_namespaces!
@@ -37,7 +37,7 @@ RSpec.describe "/sitemap.xml" do
   specify "draft book" do
     create(:book)
 
-    get "/sitemap.xml"
+    get sitemap_path
 
     xml = Capybara.string(response.body)
     xml.native.remove_namespaces!

--- a/spec/support/sign_in_as.rb
+++ b/spec/support/sign_in_as.rb
@@ -8,7 +8,7 @@ module RSpec
         :uid => provider.uid,
       })
 
-      visit "/auth/#{provider.name}/callback"
+      visit omniauth_sessions_path(provider: provider.name)
     ensure
       OmniAuth.config.mock_auth[provider.name.to_sym] = nil
     end


### PR DESCRIPTION
Benefits:

- allows to avoid string interpolation and URI escaping,
- more resilient to future changes to routes.