### PR TITLE
Have whitespace between columns in /admin

### DIFF
--- a/app/views/admin/application/index.slim
+++ b/app/views/admin/application/index.slim
@@ -5,7 +5,7 @@
 table.index
   thead
     - index_columns.each do |column|
-      th = column_name(column)
+      th => column_name(column)
     - index_action_columns.each do
       th
   tbody
@@ -14,8 +14,8 @@ table.index
         - index_columns.each do |column|
           td
             - if respond_to?("#{column}_column")
-              = public_send("#{column}_column", resource)
+              => public_send("#{column}_column", resource)
             - else
-              = resource.public_send(column)
+              => resource.public_send(column)
         - index_action_columns.each do |column|
-          td = public_send("#{column}_column", resource)
+          td => public_send("#{column}_column", resource)

--- a/spec/features/admin/authors_spec.rb
+++ b/spec/features/admin/authors_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe "Admin::AuthorsController" do
 
       expect(page).to have_content "Запис було успішно створено"
       expect(page).to have_css :h1, text: /^Автори$/
-      expect(page).to have_content "Дмитро"
-      expect(page).to have_content "Яворницький"
+      expect(page).to have_content "Дмитро Яворницький"
 
       if user == :admin
         click_on "правити"

--- a/spec/features/admin/work_types_spec.rb
+++ b/spec/features/admin/work_types_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "Admin::WorkTypesController" do
 
     expect(page).to have_content "Запис було успішно створено"
     expect(page).to have_css :h1, text: /^Типи робіт$/
-    expect(page).to have_content "Авторка тексту"
-    expect(page).to have_content "Автор тексту"
+    expect(page).to have_content "Авторка тексту Автор тексту"
 
     click_on "правити"
     expect(page).to have_field "Назва (жіночий рід)", with: "Авторка тексту"

--- a/spec/features/admin/works_spec.rb
+++ b/spec/features/admin/works_spec.rb
@@ -23,10 +23,7 @@ RSpec.describe "Admin::WorkController" do
       expect(page).to have_css :h1, text: /^Роботи$/
       expect(page.title).to eq "Роботи | Admin"
 
-      expect(page).to have_content "Зубр шукає гніздо"
-      expect(page).to have_content "Авторка тексту"
-      expect(page).to have_content "Оксана Була"
-      expect(page).to have_content "2008"
+      expect(page).to have_content "Зубр шукає гніздо Авторка тексту Оксана Була 2008"
 
       click_on "правити"
       expect(page).to have_content "Роботи / Зубр шукає гніздо - Авторка тексту - Оксана Була / Правити"


### PR DESCRIPTION
By default slim does not add whitespaces between HTML tags.
That makes asserting text quite awkward:

```html
<td>First</td>
<td>Name</td>
```

```ruby
expect(page).to have_content "FirstName"
```

By manually [adding the whitespace](https://github.com/slim-template/slim#trailing-and-leading-whitespace--) to the markup we can write 

```ruby
expect(page).to have_content "First Name"
```