### PR TITLE
Admin improvements related to author aliases.

### DIFF
--- a/app/models/author_alias.rb
+++ b/app/models/author_alias.rb
@@ -5,6 +5,7 @@
 # alias with the same #first_name, #last_name.
 class AuthorAlias < ApplicationRecord
   validates_presence_of :first_name, :last_name
+  validates_uniqueness_of :first_name, scope: [:last_name, :author_id]
 
   belongs_to :author, inverse_of: :aliases
 

--- a/app/views/admin/works/_form.slim
+++ b/app/views/admin/works/_form.slim
@@ -10,7 +10,7 @@
       a href=new_admin_work_type_path target="_blank" Add new type
   .grid-x.grid-margin-x.align-middle
     .cell.medium-6
-      = f.association :author_alias, label_method: method(:author_alias)
+      = f.association :author_alias, label_method: method(:author_alias), collection: AuthorAlias.order(:last_name, :first_name)
     .cell.medium-6
       a href=new_admin_author_path target="_blank" Add new author
   .grid-x.grid-margin-x

--- a/spec/policies/admin/author_alias_policy_spec.rb
+++ b/spec/policies/admin/author_alias_policy_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Admin::AuthorAliasPolicy do
       Pundit.policy_scope!(user, [:admin, AuthorAlias])
     end
 
-    let(:author_alias_1) { build(:author_alias) }
-    let(:author_alias_2) { build(:author_alias) }
+    let(:author_alias_1) { build(:author_alias, first_name: "Перший", last_name: "Автор") }
+    let(:author_alias_2) { build(:author_alias, first_name: "Другий", last_name: "Автор") }
     let!(:author) { create(:author, aliases: [author_alias_1, author_alias_2]) }
 
     it "returns nothing for just registered user" do


### PR DESCRIPTION
- sort aliases by last name first, then by first name on a "Create
work" screen,
- ensure uniqueness within the same author.