### PR TITLE
Let AuthorAlias factory be valid by default

### DIFF
--- a/spec/factories/author_alias.rb
+++ b/spec/factories/author_alias.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :author_alias do
-    first_name "Оксана"
+    sequence(:first_name) { |i| "Оксана (#{i})" }
     last_name "Була"
   end
 end

--- a/spec/policies/admin/author_alias_policy_spec.rb
+++ b/spec/policies/admin/author_alias_policy_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Admin::AuthorAliasPolicy do
       Pundit.policy_scope!(user, [:admin, AuthorAlias])
     end
 
-    let(:author_alias_1) { build(:author_alias, first_name: "Перший", last_name: "Автор") }
-    let(:author_alias_2) { build(:author_alias, first_name: "Другий", last_name: "Автор") }
+    let(:author_alias_1) { build(:author_alias) }
+    let(:author_alias_2) { build(:author_alias) }
     let!(:author) { create(:author, aliases: [author_alias_1, author_alias_2]) }
 
     it "returns nothing for just registered user" do


### PR DESCRIPTION
This is a follow-up to https://github.com/ua-books/ua-books/pull/79.
Once we introduced unique validation for `AuthorAlias`, it became tedious to provide unique names for each alias in case many of them are created during a single spec. The whole purpose of factories is to omit those fields that we are not interested in right now, so let the factory be valid by default by ensuring the `first_name` field is unique ("Оксана (1)", "Оксана (2) etc).