### PR TITLE
Explicitly define main AuthorAlias

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -13,5 +13,6 @@
 @include foundation-flex-classes;
 @include foundation-callout;
 @include foundation-float-classes;
+@include foundation-label;
 
 @import 'admin/*';

--- a/app/controllers/admin/author_aliases_controller.rb
+++ b/app/controllers/admin/author_aliases_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class AuthorAliasesController < Admin::ApplicationController
     expose(:index_columns) { %w[id author first_name last_name] }
+    expose(:index_action_columns) { %w[edit set_as_main] }
     expose(:author) { params[:author_id].presence && Author.find(params[:author_id]) }
     expose(:resource_collection) do
       scope = AuthorAlias.preload(:author).order(:author_id)
@@ -20,6 +21,14 @@ module Admin
         author_alias(aa.author)
       end
 
+      def set_as_main_column(aa)
+        if aa.main?
+          tag.span "головний", class: "label secondary"
+        else
+          button_to "зробити головним", set_as_main_admin_author_alias_path(aa), class: "button secondary small"
+        end
+      end
+
       def page_title(action: self.action_name)
         if author
           t "admin.author_aliases.#{action}.title_for_author", author: author_alias(author)
@@ -27,6 +36,11 @@ module Admin
           super
         end
       end
+    end
+
+    def set_as_main
+      resource.set_as_main
+      redirect_back fallback_location: admin_author_aliases_path
     end
 
     def redirect_to_after(action)

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -7,12 +7,12 @@ class Author < ApplicationRecord
   validates_inclusion_of :gender, in: %w[female male]
 
   has_many :aliases, class_name: "AuthorAlias", inverse_of: :author
-  has_one :main_alias, ->{ order(:id) }, class_name: "AuthorAlias", inverse_of: :author
+  has_one :main_alias, ->{ main }, class_name: "AuthorAlias", inverse_of: :author
 
   has_many :works, through: :aliases, inverse_of: :author
 
   after_create do
-    aliases.create!(first_name: first_name, last_name: last_name) if aliases.empty?
+    create_main_alias!(first_name: first_name, last_name: last_name) if aliases.empty?
   end
 
   def published_works

--- a/app/models/author_alias.rb
+++ b/app/models/author_alias.rb
@@ -10,4 +10,16 @@ class AuthorAlias < ApplicationRecord
   belongs_to :author, inverse_of: :aliases
 
   has_many :works, inverse_of: :aliases
+
+  scope :main, ->{ where(main: true) }
+
+  def set_as_main
+    return if main?
+
+    transaction do
+      author.main_alias.update!(main: false)
+      author.update!(first_name: first_name, last_name: last_name)
+      update!(main: true)
+    end
+  end
 end

--- a/app/policies/admin/author_alias_policy.rb
+++ b/app/policies/admin/author_alias_policy.rb
@@ -17,5 +17,9 @@ module Admin
     def create?
       user.admin? || user.publisher?
     end
+
+    def set_as_main?
+      user.admin?
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,11 @@ Rails.application.routes.draw do
     resources :books
     resources :work_types
     resources :authors
-    resources :author_aliases
+    resources :author_aliases do
+      member do
+        post :set_as_main
+      end
+    end
     resources :works
     resources :publishers
     resources :users, only: %i[index]

--- a/db/migrate/20210221153907_add_main_to_author_aliases.rb
+++ b/db/migrate/20210221153907_add_main_to_author_aliases.rb
@@ -1,0 +1,20 @@
+class AddMainToAuthorAliases < ActiveRecord::Migration[5.1]
+  def change
+    add_column :author_aliases, :main, :boolean, default: false
+    add_index :author_aliases, [:author_id, :main], unique: true, where: "main"
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          update author_aliases
+          set main = true, updated_at = now()
+          where id in (
+            select min(id)
+            from author_aliases
+            group by author_id
+          )
+        SQL
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -59,7 +59,8 @@ CREATE TABLE author_aliases (
     last_name character varying NOT NULL,
     author_id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    main boolean DEFAULT false
 );
 
 
@@ -470,6 +471,13 @@ CREATE INDEX index_author_aliases_on_author_id ON author_aliases USING btree (au
 
 
 --
+-- Name: index_author_aliases_on_author_id_and_main; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_author_aliases_on_author_id_and_main ON author_aliases USING btree (author_id, main) WHERE main;
+
+
+--
 -- Name: index_books_on_publisher_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -603,6 +611,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210110144352'),
 ('20210110154703'),
 ('20210110161606'),
-('20210110163351');
+('20210110163351'),
+('20210221153907');
 
 

--- a/spec/features/admin/author_aliases_spec.rb
+++ b/spec/features/admin/author_aliases_spec.rb
@@ -68,4 +68,19 @@ RSpec.describe "Admin::AuthorAliasesController" do
     visit edit_admin_author_alias_path(oksana_alias)
     expect(page).to have_field "Прізвище", with: "Лісу"
   end
+
+  specify "#set_as_main" do
+    create(:author_alias, first_name: "Оксана", last_name: "Була", author: oksana_bula, main: true)
+
+    visit admin_author_aliases_path
+    sign_in_as admin
+
+    expect(page).to have_content "Оксана Була Оксана Була правити головний"
+    expect(page).to have_content "Оксана Була Повелителька Туконів правити"
+
+    click_on "зробити головним"
+
+    expect(page).to have_content "Повелителька Туконів Оксана Була правити"
+    expect(page).to have_content "Повелителька Туконів Повелителька Туконів правити головний"
+  end
 end

--- a/spec/models/author_alias_spec.rb
+++ b/spec/models/author_alias_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe AuthorAlias do
+  describe "#main" do
+    specify "default alias is main" do
+      author = create(:author)
+      expect(author.main_alias).to be_main
+    end
+
+    specify "two main aliases for the same author is not allowed" do
+      author = create(:author, aliases: [build(:author_alias, main: false)])
+
+      expect {
+        create(:author_alias, main: true, author: author)
+        create(:author_alias, main: true, author: author)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    specify "two secondary aliases for the same author is allowed" do
+      author = create(:author, aliases: [build(:author_alias, main: false)])
+
+      create(:author_alias, main: false, author: author)
+      create(:author_alias, main: false, author: author)
+    end
+
+    specify "two main aliases for different authors is allowed" do
+      create(:author, aliases: [build(:author_alias, main: true)])
+      create(:author, aliases: [build(:author_alias, main: true)])
+    end
+  end
+
+  describe "#set_as_main" do
+    specify "does nothing if it is main already" do
+      main_alias = build(:author_alias, main: true)
+      create(:author, aliases: [main_alias])
+      expect {
+        main_alias.set_as_main
+      }.not_to change { main_alias.attributes }
+    end
+
+    specify "redefines self as main" do
+      author = create(:author, aliases: [build(:author_alias, main: true)])
+      secondary_alias = create(:author_alias, main: false, author: author)
+      expect {
+        secondary_alias.set_as_main
+      }.to change { secondary_alias.main }.from(false).to(true)
+    end
+
+    specify "does not touch other authors" do
+      first_author_main_alias = create(:author).main_alias
+      second_author_secondary_alias = create(:author_alias, main: false, author: create(:author))
+      expect {
+        second_author_secondary_alias.set_as_main
+      }.not_to change { first_author_main_alias.main }
+    end
+
+    specify "updates author first and last name" do
+      author = create(:author, first_name: "Оксана", last_name: "Була")
+      secondary_alias = create(:author_alias, main: false, first_name: "Повелителька", last_name: "Туконів", author: author)
+      secondary_alias.set_as_main
+      expect(author.first_name).to eq "Повелителька"
+      expect(author.last_name).to eq "Туконів"
+    end
+  end
+end

--- a/spec/policies/admin/author_alias_policy_spec.rb
+++ b/spec/policies/admin/author_alias_policy_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Admin::AuthorAliasPolicy do
     end
   end
 
-  permissions :edit?, :update? do
+  permissions :edit?, :update?, :set_as_main? do
     it "denies access to just registered user" do
       expect(policy).not_to permit(build(:user), AuthorAlias.new)
     end


### PR DESCRIPTION
Previous approach was to treat an earliest author alias as main.
That does not allow to define an alias that has been added as an author's second/third one as main.
The new approach is to have an explicit `main` boolean flag set for only one of the author's aliases.