### PR TITLE
Use less strict `match_array`

### DIFF
--- a/spec/policies/admin/author_alias_policy_spec.rb
+++ b/spec/policies/admin/author_alias_policy_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe Admin::AuthorAliasPolicy do
     end
 
     it "returns everything for publisher" do
-      expect(policy_scope(build(:publisher_user))).to match [author_alias_1, author_alias_2]
+      expect(policy_scope(build(:publisher_user))).to match_array [author_alias_1, author_alias_2]
     end
 
     it "returns everything for admin" do
-      expect(policy_scope(build(:admin))).to match [author_alias_1, author_alias_2]
+      expect(policy_scope(build(:admin))).to match_array [author_alias_1, author_alias_2]
     end
   end
 end

--- a/spec/policies/admin/author_policy_spec.rb
+++ b/spec/policies/admin/author_policy_spec.rb
@@ -58,11 +58,11 @@ RSpec.describe Admin::AuthorPolicy do
     end
 
     it "returns everything for publisher" do
-      expect(policy_scope(build(:publisher_user))).to match [author1, author2]
+      expect(policy_scope(build(:publisher_user))).to match_array [author1, author2]
     end
 
     it "returns everything for admin" do
-      expect(policy_scope(build(:admin))).to match [author1, author2]
+      expect(policy_scope(build(:admin))).to match_array [author1, author2]
     end
   end
 end

--- a/spec/policies/admin/book_policy_spec.rb
+++ b/spec/policies/admin/book_policy_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Admin::BookPolicy do
     end
 
     it "returns everything for admin" do
-      expect(policy_scope(build(:admin))).to match [book1, book2]
+      expect(policy_scope(build(:admin))).to match_array [book1, book2]
     end
 
     it "returns publisher's books for publisher" do

--- a/spec/policies/admin/publisher_policy_spec.rb
+++ b/spec/policies/admin/publisher_policy_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Admin::PublisherPolicy do
     end
 
     it "returns everything for admin" do
-      expect(policy_scope(build(:admin))).to match [publisher1, publisher2]
+      expect(policy_scope(build(:admin))).to match_array [publisher1, publisher2]
     end
 
     it "returns self for publisher" do

--- a/spec/policies/admin/work_policy_spec.rb
+++ b/spec/policies/admin/work_policy_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Admin::WorkPolicy do
     end
 
     it "returns everything for admin" do
-      expect(policy_scope(build(:admin))).to match [work1, work2]
+      expect(policy_scope(build(:admin))).to match_array [work1, work2]
     end
 
     it "returns publisher's works for publisher" do

--- a/spec/policies/admin/work_type_policy_spec.rb
+++ b/spec/policies/admin/work_type_policy_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::WorkTypePolicy do
     end
 
     it "returns everything for admin" do
-      expect(policy_scope(build(:admin))).to match [work_type1, work_type2]
+      expect(policy_scope(build(:admin))).to match_array [work_type1, work_type2]
     end
   end
 end


### PR DESCRIPTION
RSpec's `match` is strict with ordering of arrays. Usually Postgres returns
records in the order of records insertion, but this is not guaranteed, and from
time to time specs fail.

One solution is to ensure the order in tests/model before checking for results.
However, for policies spec we are not interested in the order of records
returned from DB, therefore let's use `match_array` which is order independent.