### PR TITLE
Share common `preload` arguments as scope methods

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,7 +1,7 @@
 class AuthorsController < ApplicationController
   expose(:author)
   expose(:author_works) do
-    author.published_works.preload(:type, book: {title_works: :author_alias})
+    author.published_works.preload(:type, book: Book.associations_to_preload)
   end
 
   def show

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
   expose(:books) do
-    Book.published.preload(title_works: :author_alias)
+    Book.published.preload(Book.associations_to_preload)
   end
 end

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -1,7 +1,7 @@
 class PublishersController < ApplicationController
   expose(:publisher)
   expose(:publisher_books) do
-    publisher.books.published.preload(title_works: :author_alias)
+    publisher.books.published.preload(Book.associations_to_preload)
   end
 
   def show

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -24,6 +24,10 @@ class Book < ApplicationRecord
 
   dragonfly_accessor :cover
 
+  def self.associations_to_preload
+    {title_works: :author_alias}
+  end
+
   private
 
   def publisher_page_url_should_be_valid

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -17,7 +17,7 @@ class Work < ApplicationRecord
 
   validates_uniqueness_of :book_id, scope: [:author_alias_id, :work_type_id]
 
-  def self.for_list
-    preload(:type, :author_alias, :author)
+  def self.associations_to_preload
+    [:type, :author_alias, :author]
   end
 end

--- a/app/views/books/show.slim
+++ b/app/views/books/show.slim
@@ -1,4 +1,4 @@
-- book_title = book_title(book, works: book.works.for_list)
+- book_title = book_title(book, works: book.works.preload(Work.associations_to_preload))
 - title book_title
 
 - content_for :head do
@@ -21,7 +21,7 @@ article.book-article
         dd = link_to book.publisher.name, publisher_path(id: book.publisher, slug: parameterize(publisher_title(book.publisher)))
 
       dl.inline.book-works
-        - book.works.for_list.each do |work|
+        - book.works.preload(Work.associations_to_preload).each do |work|
           dt => work_type_name(work)
           dd
             = link_to author_alias(work.author_alias), author_path(id: work.author, slug: parameterize(author_alias(work.author)))

--- a/app/views/sitemap/show.xml.slim
+++ b/app/views/sitemap/show.xml.slim
@@ -1,6 +1,6 @@
 doctype xml
 urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-  - Book.published.preload(title_works: :author_alias).each do |book|
+  - Book.published.preload(Book.associations_to_preload).each do |book|
     url
       loc = book_url(id: book.id, slug: parameterize(book_title(book, works: book.title_works)))
       changefreq always


### PR DESCRIPTION
Previous approach was to extract the whole `.preload(:arg1, :arg2)` part in a `.for_list` class method.
This works great for an immediate association like `publisher.books.for_list`, but it can't be reused for nested preloads like `author.publisher.preload(books: cant_use_Book_for_list_here)`.

The new approach is to have a class method `.associations_to_preload` which holds only arguments for `.preload` in a form of array/hash. That makes `.preload` more explicit and can be used for nested preloads – `author.publisher.preload(books: Book.associations_to_preload)`.