### PR TITLE
JSON-LD book schema

### DIFF
--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -1,0 +1,73 @@
+module JsonLdHelper
+  def book_as_json_ld(book)
+    url = book_url(id: book, slug: nil)
+
+    json = {
+      "@context": "https://schema.org",
+      "@type": "Book",
+      "@id": url,
+      "url": url,
+      "name": book.title,
+      "inLanguage": "uk",
+      "numberOfPages": book.number_of_pages,
+      "datePublished": book.published_on,
+      "publisher": publisher_as_json_ld(book.publisher),
+    }
+
+    author_works = book.works.find_all(&:author?)
+    if author_works.present?
+      json[:author] = works_as_json_ld(author_works)
+    end
+
+    illustrator_works = book.works.find_all(&:illustrator?)
+    if illustrator_works.present?
+      json[:illustrator] = works_as_json_ld(illustrator_works)
+    end
+
+    editor_works = book.works.find_all(&:editor?)
+    if editor_works.present?
+      json[:editor] = works_as_json_ld(editor_works)
+    end
+
+    contributor_works = book.works.find_all(&:contributor?)
+    if contributor_works.present?
+      json[:contributor] = works_as_json_ld(contributor_works)
+    end
+
+    if book.isbn.present?
+      json[:isbn] = book.isbn
+    end
+
+    if book.cover_uid.present?
+      json[:image] = imagekit_url(book.cover_uid, tr: {w: 640})
+    end
+
+    json
+  end
+
+  def publisher_as_json_ld(publisher)
+    url = publisher_url(id: publisher, slug: nil)
+
+    {
+      "@type": "Organization",
+      "@id": url,
+      "url": url,
+      "name": publisher_title(publisher),
+    }
+  end
+
+  def works_as_json_ld(works)
+    works.uniq { |work| work.author }.map { |work| work_as_json_ld(work) }
+  end
+
+  def work_as_json_ld(work)
+    url = author_url(id: work.author, slug: nil)
+
+    {
+      "@type": "Person",
+      "@id": url,
+      "url": url,
+      "name": author_alias(work.author),
+    }
+  end
+end

--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -29,6 +29,11 @@ module JsonLdHelper
       json[:editor] = works_as_json_ld(editor_works)
     end
 
+    translator_works = book.works.find_all(&:translator?)
+    if translator_works.present?
+      json[:translator] = works_as_json_ld(translator_works)
+    end
+
     contributor_works = book.works.find_all(&:contributor?)
     if contributor_works.present?
       json[:contributor] = works_as_json_ld(contributor_works)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -17,7 +17,7 @@ class Work < ApplicationRecord
 
   validates_uniqueness_of :book_id, scope: [:author_alias_id, :work_type_id]
 
-  delegate :author?, :editor?, :illustrator?, :contributor?, to: :type
+  delegate :author?, :editor?, :translator?, :illustrator?, :contributor?, to: :type
 
   def self.associations_to_preload
     [:type, :author_alias, :author]

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -17,6 +17,8 @@ class Work < ApplicationRecord
 
   validates_uniqueness_of :book_id, scope: [:author_alias_id, :work_type_id]
 
+  delegate :author?, :editor?, :illustrator?, :contributor?, to: :type
+
   def self.associations_to_preload
     [:type, :author_alias, :author]
   end

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -10,6 +10,7 @@ class WorkType < ApplicationRecord
   enum schema_org_role: {
     "author": "author",
     "illustrator": "illustrator",
+    "translator": "translator",
     "editor": "editor",
     "contributor": "contributor",
   }

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -6,4 +6,11 @@
 class WorkType < ApplicationRecord
   validates_presence_of :name_feminine, :name_masculine
   validates_uniqueness_of :name_feminine, :name_masculine
+
+  enum schema_org_role: {
+    "author": "author",
+    "illustrator": "illustrator",
+    "editor": "editor",
+    "contributor": "contributor",
+  }
 end

--- a/app/views/admin/work_types/_form.slim
+++ b/app/views/admin/work_types/_form.slim
@@ -1,4 +1,5 @@
 = simple_form_for [:admin, resource] do |f|
   = f.input :name_feminine
   = f.input :name_masculine
+  = f.input :schema_org_role, collection: WorkType.schema_org_roles
   = f.submit class: "button"

--- a/app/views/books/show.slim
+++ b/app/views/books/show.slim
@@ -46,3 +46,5 @@ article.book-article
   - if book.description_md.present?
     .description
       = markdown(book.description_md)
+
+script type="application/ld+json" == book_as_json_ld(book).to_json

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -46,6 +46,7 @@ uk:
       work_type:
         name_feminine: Назва (жіночий рід)
         name_masculine: Назва (чоловічий рід)
+        schema_org_role: Роль (за schema.org)
       work:
         title: У заголовку
         book: Книга

--- a/db/migrate/20210411153603_add_schema_org_role_to_work_types.rb
+++ b/db/migrate/20210411153603_add_schema_org_role_to_work_types.rb
@@ -1,0 +1,5 @@
+class AddSchemaOrgRoleToWorkTypes < ActiveRecord::Migration[5.1]
+  def change
+    add_column :work_types, :schema_org_role, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -272,7 +272,8 @@ CREATE TABLE work_types (
     name_feminine character varying NOT NULL,
     name_masculine character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    schema_org_role character varying
 );
 
 
@@ -622,6 +623,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210110163351'),
 ('20210221153907'),
 ('20210321192243'),
-('20210328153338');
+('20210328153338'),
+('20210411153603');
 
 

--- a/spec/factories/work_type.rb
+++ b/spec/factories/work_type.rb
@@ -3,16 +3,25 @@ FactoryGirl.define do
     factory :text_author_type do
       name_feminine "Авторка тексту"
       name_masculine "Автор тексту"
+      schema_org_role "author"
     end
 
     factory :illustrator_type do
       name_feminine "Ілюстраторка"
       name_masculine "Ілюстратор"
+      schema_org_role "illustrator"
     end
 
     factory :chief_editor_type do
       name_feminine "Головна редакторка"
       name_masculine "Головний редактор"
+      schema_org_role "editor"
+    end
+
+    factory :en_translator_type do
+      name_feminine "Переклала з англійської"
+      name_masculine "Переклав з англійської"
+      schema_org_role "contributor"
     end
   end
 end

--- a/spec/factories/work_type.rb
+++ b/spec/factories/work_type.rb
@@ -21,6 +21,12 @@ FactoryGirl.define do
     factory :en_translator_type do
       name_feminine "Переклала з англійської"
       name_masculine "Переклав з англійської"
+      schema_org_role "translator"
+    end
+
+    factory :project_manager do
+      name_feminine "Керівниця проєкту"
+      name_masculine "Керівник проєкту"
       schema_org_role "contributor"
     end
   end

--- a/spec/features/admin/work_types_spec.rb
+++ b/spec/features/admin/work_types_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Admin::WorkTypesController" do
 
     fill_in "Назва (жіночий рід)", with: "Авторка тексту"
     fill_in "Назва (чоловічий рід)", with: "Автор тексту"
+    select "author", from: "Роль (за schema.org)"
     click_on "Додати тип робіт"
 
     expect(page).to have_content "Запис було успішно створено"
@@ -25,6 +26,7 @@ RSpec.describe "Admin::WorkTypesController" do
     click_on "правити"
     expect(page).to have_field "Назва (жіночий рід)", with: "Авторка тексту"
     expect(page).to have_field "Назва (чоловічий рід)", with: "Автор тексту"
+    expect(page).to have_select "Роль (за schema.org)", selected: "author"
   end
 
   specify "#update" do

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe JsonLdHelper do
+  describe "#book_as_json_ld" do
+    specify "base fields" do
+      publisher = build(
+        :publisher,
+        id: 7,
+        name: "Видавництво Старого Лева",
+      )
+
+      book = create(
+        :book,
+        id: 3,
+        title: "Зубр шукає гніздо",
+        number_of_pages: 60,
+        published_on: Date.new(2020, 5, 3),
+        publisher: publisher,
+      )
+
+      result = helper.book_as_json_ld(book)
+
+      expect(result).to eq(
+        "@context": "https://schema.org",
+        "@type": "Book",
+        "@id": "http://test.host/3",
+        "url": "http://test.host/3",
+        "name": "Зубр шукає гніздо",
+        "inLanguage": "uk",
+        "numberOfPages": 60,
+        "datePublished": Date.new(2020, 5, 3),
+        "publisher": {
+          "@type": "Organization",
+          "@id": "http://test.host/p/7",
+          "url": "http://test.host/p/7",
+          "name": "Видавництво Старого Лева",
+        }
+      )
+    end
+
+    specify "isbn" do
+      book = create(:book, isbn: "9786177538492")
+
+      result = helper.book_as_json_ld(book)
+
+      expect(result).to include(
+        isbn: "9786177538492",
+      )
+    end
+
+    specify "cover image" do
+      book = create(:book, cover_uid: "336.jpg")
+
+      result = helper.book_as_json_ld(book)
+
+      expect(result).to include(
+        image: "https://ik.imagekit.io/uabooks/tr:w-640/336.jpg",
+      )
+    end
+
+    context "contributors" do
+      let(:author) { create(:author, id: 4, first_name: "Оксана", last_name: "Була") }
+      let(:book) { create(:book) }
+
+      specify "author" do
+        work_type = create(:text_author_type)
+        create(:work, author_alias: author.main_alias, type: work_type, book: book)
+
+        result = helper.book_as_json_ld(book)
+
+        expect(result).to include(
+          author: [{
+            "@type": "Person",
+            "@id": "http://test.host/a/4",
+            "url": "http://test.host/a/4",
+            "name": "Оксана Була",
+          }]
+        )
+      end
+
+      specify "illustrator" do
+        work_type = create(:illustrator_type)
+        create(:work, author_alias: author.main_alias, type: work_type, book: book)
+
+        result = helper.book_as_json_ld(book)
+
+        expect(result).to include(
+          illustrator: [{
+            "@type": "Person",
+            "@id": "http://test.host/a/4",
+            "url": "http://test.host/a/4",
+            "name": "Оксана Була",
+          }]
+        )
+      end
+
+      specify "editor" do
+        work_type = create(:chief_editor_type)
+        create(:work, author_alias: author.main_alias, type: work_type, book: book)
+
+        result = helper.book_as_json_ld(book)
+
+        expect(result).to include(
+          editor: [{
+            "@type": "Person",
+            "@id": "http://test.host/a/4",
+            "url": "http://test.host/a/4",
+            "name": "Оксана Була",
+          }]
+        )
+      end
+
+      specify "contributor" do
+        work_type = create(:en_translator_type)
+        create(:work, author_alias: author.main_alias, type: work_type, book: book)
+
+        result = helper.book_as_json_ld(book)
+
+        expect(result).to include(
+          contributor: [{
+            "@type": "Person",
+            "@id": "http://test.host/a/4",
+            "url": "http://test.host/a/4",
+            "name": "Оксана Була",
+          }]
+        )
+      end
+    end
+  end
+end

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -110,8 +110,24 @@ RSpec.describe JsonLdHelper do
         )
       end
 
-      specify "contributor" do
+      specify "translator" do
         work_type = create(:en_translator_type)
+        create(:work, author_alias: author.main_alias, type: work_type, book: book)
+
+        result = helper.book_as_json_ld(book)
+
+        expect(result).to include(
+          translator: [{
+            "@type": "Person",
+            "@id": "http://test.host/a/4",
+            "url": "http://test.host/a/4",
+            "name": "Оксана Була",
+          }]
+        )
+      end
+
+      specify "contributor" do
+        work_type = create(:project_manager)
         create(:work, author_alias: author.main_alias, type: work_type, book: book)
 
         result = helper.book_as_json_ld(book)


### PR DESCRIPTION
It is unclear, does Google prefer pages with schema.org markup or not, especially when it comes to [Book format](https://schema.org/Book). Actually, it is even not clear, do they support it at all, because [this page](https://developers.google.com/search/docs/data-types/book) is only about feeds (enabled for large book providers only) and [test rich results](https://search.google.com/test/rich-results) shows no rich preview is supported for the page. Also Book format is not listed [here](https://support.google.com/webmasters/answer/7445569#zippy=,supported-types).

Still, it is possible that Google may rank such pages higher and does not advertise this.
[Review snippets](https://developers.google.com/search/docs/data-types/review-snippet) are definitely supported (to be implemented in the future), and they have to be attached to a book.

`WorkType#schema_org_role` may contain a value from the list: author, illustrator, translator, editor, contributor. These are pre-defined roles from https://schema.org/Book. It is also possible to define [custom roles](http://blog.schema.org/2014/06/introducing-role.html), but these are definitely not supported by Google (actually, only "author" role is recognized by them currently).