### PR TITLE
Pre-installing `psql` is no longer needed on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,6 @@ jobs:
       - checkout
       - ruby/install-deps
       - run:
-          command: 'sudo apt-get update && sudo apt install -y postgresql-client'
-          name: Install psql
-      - run:
           command: 'dockerize -wait tcp://localhost:5432 -timeout 1m'
           name: Wait for DB
       - run:


### PR DESCRIPTION
Related - https://github.com/ua-books/ua-books/pull/73
See the [request to include `psql` by default](https://github.com/CircleCI-Public/cimg-base/issues/91) in the Docker image.