### PR TITLE
Use latest circleci/ruby orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@1.1.2 
+  ruby: circleci/ruby@1.8.0
 jobs:
   test:
     docker:


### PR DESCRIPTION
### Problem

When a single gem version is changed in Gemfile.lock we completely discard previous gems cache on Circle CI and install everything from scratch.

### Solution

Use master's cache, unpack it, then install over it, which will fetch only updated and/or new gems.
This was handled in https://github.com/CircleCI-Public/ruby-orb/pull/65